### PR TITLE
Updated templates in the parm

### DIFF
--- a/parm/data_table.IN
+++ b/parm/data_table.IN
@@ -1,0 +1,1 @@
+"OCN", "runoff", "runoff", "./INPUT/runoff.daitren.clim.1440x1080.v20180328.nc", "none" ,  1.0

--- a/parm/diag_table_template
+++ b/parm/diag_table_template
@@ -1,5 +1,5 @@
-YMD.00Z.C96.64bit.non-mono
-SYEAR SMONTH SDAY 00 0 0
+YMD.SHOURZ.C96.64bit.non-mono
+SYEAR SMONTH SDAY SHOUR 0 0
 
 ######################
 "ocn%4yr%2mo%2dy%2hr",      6,  "hours", 1, "hours", "time", 6, "hours", "1901 1 1 0 0 0"
@@ -21,6 +21,7 @@ SYEAR SMONTH SDAY 00 0 0
  "ocean_model", "wet_v",       "wet_v",       "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
  "ocean_model", "sin_rot",     "sin_rot",     "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
  "ocean_model", "cos_rot",     "cos_rot",     "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "area_t",      "area_t",      "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
 
 # ocean output TSUV and others
  "ocean_model", "SSH",       "SSH",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
@@ -33,6 +34,8 @@ SYEAR SMONTH SDAY 00 0 0
  "ocean_model", "ePBL_h_ML", "ePBL",     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model", "MLD_003",   "MLD_003",  "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2 
  "ocean_model", "MLD_0125",  "MLD_0125", "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "vmo",       "vmo",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "umo",       "umo",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
 
 # save daily SST
  "ocean_model", "geolon",      "geolon",      "SST%4yr%2mo%2dy", "all", .false., "none", 2
@@ -55,6 +58,7 @@ SYEAR SMONTH SDAY 00 0 0
  "ocean_model_z","vo","vo"      ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model_z","so","so"      ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model_z","temp","temp"  ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model_z","e","e"        ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
 
 # forcing
  "ocean_model", "taux",      "taux",                     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
@@ -70,6 +74,8 @@ SYEAR SMONTH SDAY 00 0 0
  "ocean_model", "fprec",     "fprec",                    "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model", "LwLatSens", "LwLatSens",                "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model", "Heat_PmE",  "Heat_PmE",                 "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "hfds",      "hfds",                     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "PRCmE",     "PRCmE",                    "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
 
 #=============================================================================================
 #=============================================================================================

--- a/parm/ice_in_template
+++ b/parm/ice_in_template
@@ -4,19 +4,19 @@
   , year_init      = YEAR_INIT
   , istep0         = ISTEP0
   , dt             = DT_CICE
-  , npt            = 999
+  , npt            = NPT
   , ndtd           = 1
   , runtype        = 'RUNTYPE' 
   , runid          = 'RUNID' 
-  , ice_ic         = 'cice5_model.res.nc'
+  , ice_ic         = 'ICE_IC_NAME'
   , restart        = .true.
   , restart_ext    = .false.
   , use_restart_time = USE_RESTART_TIME
   , restart_format = 'nc'
   , lcdf64         = .false.
-  , restart_dir    = './RESTART/'
+  , restart_dir    = './restart/'
   , restart_file   = 'iced'
-  , pointer_file   = './ice.restart_file'
+  , pointer_file   = './restart/ice.restart_file'
   , dumpfreq       = 'DUMPFREQ'
   , dumpfreq_n     =  DUMPFREQ_N
   , dump_last      = .false.  
@@ -43,8 +43,8 @@
 &grid_nml
     grid_format  = 'nc'
   , grid_type    = 'displaced_pole'
-  , grid_file    = 'grid_cice_NEMS_mx025.nc'
-  , kmt_file     = 'kmtu_cice_NEMS_mx025.nc'
+  , grid_file    = 'ICE_GRID_FILE'
+  , kmt_file     = 'ICE_KMT_FILE'
   , kcatbound    = 0
 /
 
@@ -71,8 +71,8 @@
   , restart_pond_cesm = .false.
   , tr_pond_topo = .false.
   , restart_pond_topo = .false.
-  , tr_pond_lvl  = .true.
-  , restart_pond_lvl  = .false.
+  , tr_pond_lvl  = TR_POND_LVL
+  , restart_pond_lvl  = RESTART_POND_LVL
   , tr_aero      = .false.
   , restart_aero = .false.
 /

--- a/parm/input.mom6.nml.IN
+++ b/parm/input.mom6.nml.IN
@@ -8,7 +8,7 @@
          output_directory = 'MOM6_OUTPUT/',
          input_filename = '@[MOM6_RESTART_SETTING]'
          restart_input_dir = 'INPUT/',
-         restart_output_dir = 'RESTART/',
+         restart_output_dir = '@[RESTART]/',
          parameter_filename = 'INPUT/MOM_input',
                               'INPUT/MOM_override' /
 

--- a/parm/nems.configure.med_atm_ocn_ice.IN
+++ b/parm/nems.configure.med_atm_ocn_ice.IN
@@ -12,9 +12,9 @@ EARTH_attributes::
 MED_model:                      @[med_model]
 MED_petlist_bounds:             @[med_petlist_bounds]
 MED_attributes::
-  DumpFields = false
+  DumpFields = @[DumpFields]
   DumpRHs = false
-  coldstart = false
+  coldstart = @[coldstart]
   restart_interval = @[RESTART_INTERVAL]
   ProfileMemory = false
   AoMedFlux = true
@@ -24,8 +24,8 @@ MED_attributes::
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
 ATM_attributes::
-  coldstart = false
-  DumpFields = false
+  coldstart = @[coldstart]
+  DumpFields = @[DumpFields]
   ProfileMemory = false
 ::
 

--- a/parm/nems.configure.medcold_atm_ocn_ice.IN
+++ b/parm/nems.configure.medcold_atm_ocn_ice.IN
@@ -13,9 +13,9 @@ MED_model:                      @[med_model]
 MED_petlist_bounds:             @[med_petlist_bounds]
 MED_attributes::
   Verbosity = 0
-  DumpFields = false
+  DumpFields = @[DumpFields]
   DumpRHs = false
-  coldstart = true
+  coldstart = @[coldstart]
   ProfileMemory = false
   AoMedFlux = true
 ::
@@ -24,7 +24,7 @@ MED_attributes::
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
 ATM_attributes::
-  DumpFields = false
+  DumpFields =  @[DumpFields]
   ProfileMemory = false
 ::
 
@@ -32,7 +32,7 @@ ATM_attributes::
 OCN_model:                      @[ocn_model]
 OCN_petlist_bounds:             @[ocn_petlist_bounds]
 OCN_attributes::
-  DumpFields = false
+  DumpFields = @[DumpFields]
   ProfileMemory = false
 ::
 
@@ -40,7 +40,7 @@ OCN_attributes::
 ICE_model:                      @[ice_model]
 ICE_petlist_bounds:             @[ice_petlist_bounds]
 ICE_attributes::
-  DumpFields = false
+  DumpFields =  @[DumpFields]
   ProfileMemory = false
 ::
 


### PR DESCRIPTION
The files in the parm folder have been updated to be used directly with GODAS and avoiding the local copies and modifications. 

The update removes some of the predefined values and adds variables to be substituted by the users.  

closes #21 